### PR TITLE
Add .otc support, fix invalid .ttc/.otc handling and update readme.md to match the new features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # font-rename
 
-rename fonts & unpack ttc
+Rename fonts to their internal name and unpack .ttc/.otc files.
 
 ```bash
-pipx install font-rename
-font-rename ~/fonts/aaa.ttc
+pip install font-rename
+font-rename insert/directory/file/path/here
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # font-rename
 
-Rename fonts to their internal name and unpack .ttc/.otc files.
+Renames fonts to their internal name and unpacks .ttc/.otc files.
 
 ```bash
 pip install font-rename

--- a/font_rename.py
+++ b/font_rename.py
@@ -95,6 +95,8 @@ def handle_file(filepath: Path):
     suffix = filepath.suffix.lower()
     if suffix == ".ttc":
         unpack_ttc(filepath)
+    if suffix == ".otc":
+        unpack_ttc(filepath)
     else:
         rename_font(filepath)
 

--- a/font_rename.py
+++ b/font_rename.py
@@ -79,7 +79,11 @@ def rename_font(filepath: Path):
 
 
 def unpack_ttc(filepath: Path):
-    collection = TTCollection(str(filepath.resolve()))
+    try:
+        collection = TTCollection(str(filepath.resolve()))
+    except:
+        print(f"Failed to parse {filepath}, ignore")
+        return
     for font in collection.fonts:
         ttf_path = filepath.parent / f"{get_font_name(font)}.ttf"
         font.save(ttf_path)

--- a/font_rename.py
+++ b/font_rename.py
@@ -91,12 +91,25 @@ def unpack_ttc(filepath: Path):
     filepath.unlink()
 
 
+def unpack_otc(filepath: Path):
+    try:
+        collection = TTCollection(str(filepath.resolve()))
+    except:
+        print(f"Failed to parse {filepath}, ignore")
+        return
+    for font in collection.fonts:
+        ttf_path = filepath.parent / f"{get_font_name(font)}.otf"
+        font.save(ttf_path)
+        print(f"{filepath} -> {ttf_path}")
+    filepath.unlink()
+
+
 def handle_file(filepath: Path):
     suffix = filepath.suffix.lower()
     if suffix == ".ttc":
         unpack_ttc(filepath)
     if suffix == ".otc":
-        unpack_ttc(filepath)
+        unpack_otc(filepath)
     else:
         rename_font(filepath)
 


### PR DESCRIPTION
This PR adds support for unpacking .otc files. It also causes the script to print an error message and then continue when the script encounters a broken .ttc/.otc file. Previously, when the script encountered an invalid .ttc/.otc file it would refuse to parse any of the files in the directory. It also updates the readme.md to include the new features added in the PR.