### PR TITLE
Add the option to remove unparsable fonts

### DIFF
--- a/font_rename.py
+++ b/font_rename.py
@@ -9,7 +9,7 @@ from fontTools.ttLib.tables._n_a_m_e import table__n_a_m_e as NameTable, NameRec
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("-ru", "--remove-unparsable", dest="ru", action="store_true", help="When this option is enabled, unparsable fonts are removed instead of ignored")
+parser.add_argument("-ru", "--remove-unparsable", dest="remove_unparsable", action="store_true", help="When this option is enabled, unparsable fonts are removed instead of ignored")
 
 args, unknown = parser.parse_known_args()
 
@@ -72,7 +72,7 @@ def rename_font(filepath: Path):
     try:
         font = TTFont(str(filepath.resolve()))
     except:
-        if args.ru:
+        if args.remove_unparsable:
             print(f"Failed to parse {filepath}, removing")
             os.remove(filepath)
             return

--- a/font_rename.py
+++ b/font_rename.py
@@ -114,11 +114,11 @@ def unpack_otc(filepath: Path):
 def handle_file(filepath: Path):
     suffix = filepath.suffix.lower()
     if suffix == ".ttc":
-       unpack_ttc(filepath)
+        unpack_ttc(filepath)
     if suffix == ".otc":
-       unpack_otc(filepath)
+        unpack_otc(filepath)
     else:
-       rename_font(filepath)
+        rename_font(filepath)
 
 
 def handle_path(path: Path):

--- a/font_rename.py
+++ b/font_rename.py
@@ -7,6 +7,11 @@ import os
 from fontTools.ttLib import TTFont, TTCollection
 from fontTools.ttLib.tables._n_a_m_e import table__n_a_m_e as NameTable, NameRecord
 
+parser = argparse.ArgumentParser()
+
+parser.add_argument("-ru", "--remove-unparsable", dest="remove_unparsable", action="store_true", help="When this option is enabled, unparsable fonts are removed instead of ignored")
+
+args, unknown = parser.parse_known_args()
 
 PREFERRED_IDS = (
     (3, 1, 0x0C04),
@@ -114,11 +119,11 @@ def unpack_otc(filepath: Path):
 def handle_file(filepath: Path):
     suffix = filepath.suffix.lower()
     if suffix == ".ttc":
-        unpack_ttc(filepath)
+       unpack_ttc(filepath)
     if suffix == ".otc":
-        unpack_otc(filepath)
+       unpack_otc(filepath)
     else:
-        rename_font(filepath)
+       rename_font(filepath)
 
 
 def handle_path(path: Path):
@@ -131,10 +136,6 @@ def handle_path(path: Path):
         handle_file(path)
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-ru", "--remove-unparsable", dest="remove_unparsable", action="store_true", help="When this option is enabled, unparsable fonts are removed instead of ignored")
-    args, unknown = parser.parse_known_args()
-    
     if len(sys.argv) == 1:
         print(f"Usage: {sys.argv[0]} [<files>]")
     else:

--- a/font_rename.py
+++ b/font_rename.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import sys
 import argparse
-import atexit
 from pathlib import Path
 import cchardet as chardet
 import os

--- a/font_rename.py
+++ b/font_rename.py
@@ -7,11 +7,6 @@ import os
 from fontTools.ttLib import TTFont, TTCollection
 from fontTools.ttLib.tables._n_a_m_e import table__n_a_m_e as NameTable, NameRecord
 
-parser = argparse.ArgumentParser()
-
-parser.add_argument("-ru", "--remove-unparsable", dest="remove_unparsable", action="store_true", help="When this option is enabled, unparsable fonts are removed instead of ignored")
-
-args, unknown = parser.parse_known_args()
 
 PREFERRED_IDS = (
     (3, 1, 0x0C04),
@@ -136,6 +131,10 @@ def handle_path(path: Path):
         handle_file(path)
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-ru", "--remove-unparsable", dest="remove_unparsable", action="store_true", help="When this option is enabled, unparsable fonts are removed instead of ignored")
+    args, unknown = parser.parse_known_args()
+    
     if len(sys.argv) == 1:
         print(f"Usage: {sys.argv[0]} [<files>]")
     else:

--- a/font_rename.py
+++ b/font_rename.py
@@ -74,7 +74,7 @@ def rename_font(filepath: Path):
     except:
         if args.remove_unparsable:
             print(f"Failed to parse {filepath}, removing")
-            os.remove(filepath)
+            filepath.unlink()
             return
         else:
             print(f"Failed to parse {filepath}, ignore")

--- a/font_rename.py
+++ b/font_rename.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import sys
 import argparse
 from pathlib import Path
 import cchardet as chardet
@@ -11,7 +10,9 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("-ru", "--remove-unparsable", dest="remove_unparsable", action="store_true", help="When this option is enabled, unparsable fonts are removed instead of ignored")
 
-args, unknown = parser.parse_known_args()
+parser.add_argument("files", nargs="+")
+
+args, unknown = parser.parse_known_intermixed_args()
 
 PREFERRED_IDS = (
     (3, 1, 0x0C04),
@@ -135,13 +136,10 @@ def handle_path(path: Path):
     else:
         handle_file(path)
 
+
 def main():
-    if len(sys.argv) == 1:
-        print(f"Usage: {sys.argv[0]} [<files>]")
-    else:
-        for path in sys.argv[1:]:
-            if not path.startswith("-"):
-                handle_path(Path(path))
+    for path in args.files:
+        handle_path(Path(path))
 
 
 if __name__ == "__main__":

--- a/font_rename.py
+++ b/font_rename.py
@@ -119,11 +119,11 @@ def unpack_otc(filepath: Path):
 def handle_file(filepath: Path):
     suffix = filepath.suffix.lower()
     if suffix == ".ttc":
-       unpack_ttc(filepath)
+        unpack_ttc(filepath)
     if suffix == ".otc":
-       unpack_otc(filepath)
+        unpack_otc(filepath)
     else:
-       rename_font(filepath)
+        rename_font(filepath)
 
 
 def handle_path(path: Path):


### PR DESCRIPTION
This commit adds the option to remove unparsable fonts as opposed to printing an error message (not collections, due to the way the script handles them. working on that). It also adds support for creating further argparse arguments while keeping the sys.argv path variable intact.